### PR TITLE
fix #11: OSX: No module named scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pronouncing==0.1.2
 pyttsx==1.1
 pybrain==0.3
 markovify==0.5.4
+scipy==0.13.0b1


### PR DESCRIPTION
Added scipy dependency.

Fix: https://github.com/robbiebarrat/rapping-neural-network/issues/11